### PR TITLE
Replace `time` with `bigeasy/timezone`.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,12 @@ var fs = require('fs');
 var geolib = require('geolib');
 var path = require('path');
 var sets = require('simplesets');
-var time = require('time');
+// Create a Timezone function that knows about all the world's time zones. Add a
+// custom `strftime` format specifier `%+` that returns the time zone offset in
+// milliseconds.
+var tz = require('timezone')(require('timezone/zones'), function () {
+  this["+"] = function () { return this.entry.offset + this.entry.save }
+});
 
 // The "shortcut" iterates the timezone polygons when they are read in, and
 // determines the minimum/maximum longitude of each.  Because there are what
@@ -161,18 +166,20 @@ var dateIn = function () {
   if (arguments.length === 0) {
     return null;
   } else {
-    // If no date constructor given, use "now".
-    var args = (arguments.length === 1 ? [Date.now(), arguments[0]] : arguments);
-    var ret = time.Date.apply(new time.Date(), args);
-    // Return the raw UTC milliseconds of the calculated time.  The Date
-    // object is constructed of pure evil, and we must limit our exposure.
-    return +ret;
+    var vargs = [], tzname, date;
+    vargs.push.apply(vargs, arguments);
+    tzname = vargs.pop();
+    vargs.length > 1 && vargs[1]++; // zero month to humane month.
+    date = vargs.length ? vargs.length == 1 ? vargs[0] : vargs.slice(0, 7) : Date.now();
+    return tz(date, tzname);
   }
 };
 
-// Accepts latitude, longitude, ... where ... are arguments applicable to a
-// "new Date(...)" call (actually a Date.UTC(...) call because we need time
-// in UTC to pass to the timezone-shifting dateIn function)
+// Accepts latitude, longitude, ... where ... are arguments applicable to a "new
+// Date(...)" call.
+//
+// Like new Date() and unlike Date.UTC(), dateAt() treats a single integer value
+// as milliseconds since the epoch.
 var dateAt = function () {
   var tzname = tzNameAt(arguments[0], arguments[1]);
   if (tzname) {
@@ -190,18 +197,20 @@ var dateAt = function () {
 // UTC happens in local time for multiple timezones around the world.
 // Personally I don't get much use out of it, YMMV.
 // Why milliseconds?  Because it's the time denomination of choice for JS.
+//
+// Now accepts a wall clock time for the location and converts the wall clock
+// time to the time zone offset for the location at the given wall clock time.
+//
+// Like new Date() and unlike Date.UTC(), tzOffsetAt() treats a single integer
+// value as milliseconds since the epoch.
 var tzOffsetAt = function () {
-  var tzname = tzNameAt(arguments[0], arguments[1]);
+  var vargs = [], tzname, date;
+  vargs.push.apply(vargs, arguments);
+  tzname = tzNameAt(vargs.shift(), vargs.shift());
   if (tzname) {
-    var comparisonDate = Date.now();
-    var utc = dateIn(comparisonDate, 'UTC');
-    var local = dateIn(comparisonDate, tzname);
-    // utc - local = offset
-    // utc + offset = local
-    // Note that for reasons beyond my comprehension, sometimes the time
-    // library I'm using decides that timezones are off by some 1 hour and
-    // three seconds.  Which is an interesting choice that I disregard here:
-    return Math.round((utc - local) / 3600000) * 3600000;
+    vargs.length > 1 && vargs[1]++; // zero month to humane month.
+    date = vargs.length ? vargs.length == 1 ? vargs[0] : vargs.slice(0, 7) : Date.now();
+    return + tz(date, '%+', tzname);
   }
   return null;
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "geolib": "git://github.com/manuelbieh/Geolib.git",
     "simplesets": "1.2.0",
-    "time": "0.8.1"
+    "timezone": "0.0.14"
   },
   "devDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
Replace the C++ based time library with the pure JavaScript Timezone library, version 0.0.14. We'll use a frozen version number for Timezone while it's major version is the pre-release `0`.

Update `tzOffsetAt` to accept a wall-clock time, instead of only ever using `Date.now()`. The wall-clock time is passed to the Timezone function as an array of date filed, along with the time zone name and a custom format specifier. The custom format specifier returns the time zone offset in milliseconds. The Timezone function returns the output of the custom format specifier which is converted to integer and returned from `tzOffsetAt`.

Removed fixup for incorrect time zone offset.

Update `dateIn` to use a date field array and a time zone to convert wall-clock time to POSIX time.

Note that the `dateIn` and `tzOffsetAt` follow the `new Date` convention of interpeting a single argument as POSIX time. To specify the first of the year, you must specify at least the year and the month. Any field left null is zero filled.

Timezone uses a one-based month number, so we need to convert this.

Also, if you pass in a single argument that is an RFC 3999 date string, `dateIn` and `tzOffsetAt` will parse it as wall-clock time, fi the date string does not explicitly specify a time zone offset.

Nonsense gets you `null`.

Current tests passing on Fedora 16.

Related issues: mattbornski/tzwhere#2.
