### PR TITLE
Update Timezone to 0.0.16.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "geolib": "git://github.com/manuelbieh/Geolib.git",
     "simplesets": "1.2.0",
-    "timezone": "0.0.14"
+    "timezone": "0.0.16"
   },
   "devDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
Update Timezone from 0.0.14 to 0.0.16.

Timezone 0.0.16 has been updated to include the `tzdata2012j` version of the IANA timezone database, plus support for many more locales was added in Timezone 0.0.15.

You should still use a specific version of Timezone in your `package.json`. A stable `0.2.0` release is pending. It will allow for a `~0.2` version pattern.
