### PR TITLE
Upgrade timezone version to fix silent failure on windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "geolib": "1.2.5",
     "simplesets": "1.2.0",
-    "timezone": "0.0.19"
+    "timezone": "0.0.48"
   },
   "devDependencies": {
     "mocha": "1.x"


### PR DESCRIPTION
Yesterday I saw a [comment](https://github.com/mattbornski/tzwhere/issues/13#issuecomment-181757540) about this existing issue. I did many tests and finally checked that upgrading lib version it works on windows.